### PR TITLE
EPI: Fix issues detected by Checkov 

### DIFF
--- a/.checkov/epi/.checkov.yaml
+++ b/.checkov/epi/.checkov.yaml
@@ -1,0 +1,16 @@
+compact: true
+directory:
+- charts/epi
+download-external-modules: false
+evaluate-variables: true
+external-modules-download-path: .external_modules
+framework:
+- helm
+quiet: true
+skip-check:
+- CKV_K8S_21
+- CKV_K8S_15
+soft-fail: true
+var-file:
+- .checkov/epi/values.yaml
+output: cli

--- a/.checkov/epi/values.yaml
+++ b/.checkov/epi/values.yaml
@@ -1,0 +1,39 @@
+# image:
+#   sha: "somedigest"
+
+# # -- Security Context for the pod.
+# # See [https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
+# # and [https://kubernetes.io/docs/tutorials/security/seccomp/](https://kubernetes.io/docs/tutorials/security/seccomp/)
+# podSecurityContext:
+#   runAsUser: 1000
+#   seccompProfile:
+#     type: RuntimeDefault
+
+# # -- Security Context for the container.
+# # See [https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container)
+# securityContext:
+#   capabilities:
+#     drop:
+#     - ALL
+#   readOnlyRootFilesystem: true
+#   allowPrivilegeEscalation: false
+#   runAsNonRoot: true
+#   runAsUser: 1000
+
+# config:
+#   smartContractAddress: "someaddress"
+
+# secrets:
+#   # -- Org Account in JSON format.
+#   # This value must be set or orgAccountJsonBase64.
+#   orgAccountJson: "someOrgAccount"
+
+# # -- Resource constraints for a pod
+# resources:
+#   limits:
+#     cpu: 100m
+#     memory: 128Mi
+#   requests:
+#     cpu: 5m
+#     memory: 128Mi
+

--- a/.github/workflows/validate_code.yaml
+++ b/.github/workflows/validate_code.yaml
@@ -52,3 +52,12 @@ jobs:
           # we need to override these values as they will always set by the github action
           directory: 'charts/ethadapter' # we need to set this value! - see https://github.com/bridgecrewio/checkov-action/issues/77
           output_format: 'cli' # override default value 'sarif'  - https://github.com/bridgecrewio/checkov-action/blob/v12.1469.0/action.yml#L37
+
+      # https://github.com/bridgecrewio/checkov-action/tree/v12.1469.0
+      - uses: bridgecrewio/checkov-action@85bd3080490ce5978dce5f754a993c42b1ef1d2b # v12.1469.0
+        name: Checkov epi
+        with:
+          config_file: .checkov/epi/.checkov.yaml
+          # we need to override these values as they will always set by the github action
+          directory: 'charts/epi' # we need to set this value! - see https://github.com/bridgecrewio/checkov-action/issues/77
+          output_format: 'cli' # override default value 'sarif'  - https://github.com/bridgecrewio/checkov-action/blob/v12.1469.0/action.yml#L37


### PR DESCRIPTION
1. Added Checkov for epi
2. Added support for image digest (CKV_K8S_43), see [https://docs.bridgecrew.io/docs/bc_k8s_39](https://docs.bridgecrew.io/docs/bc_k8s_39)
3. By default do not mount service account token to epi pod (CKV_K8S_38), see [https://docs.bridgecrew.io/docs/bc_k8s_35](https://docs.bridgecrew.io/docs/bc_k8s_35)