### PR TITLE
GH action: run pre-commit for well defined charts only

### DIFF
--- a/.github/workflows/validate_code.yaml
+++ b/.github/workflows/validate_code.yaml
@@ -36,8 +36,6 @@ jobs:
 
       - uses: pre-commit/action@9b88afc9cd57fd75b655d5c71bd38146d07135fe # v2.0.3
         name: Run pre-commit
-        with:
-          extra_args: helm-docs --files charts/epi/** charts/ethadapter/** charts/fgt/** charts/quorum-node/**
 
   checkov:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate_code.yaml
+++ b/.github/workflows/validate_code.yaml
@@ -36,6 +36,8 @@ jobs:
 
       - uses: pre-commit/action@9b88afc9cd57fd75b655d5c71bd38146d07135fe # v2.0.3
         name: Run pre-commit
+        with:
+          extra_args: helm-docs --files charts/epi/** charts/ethadapter/** charts/fgt/** charts/quorum-node/**
 
   checkov:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,7 @@ repos:
   rev: v1.8.1
   hooks:
     - id: helm-docs
+      files: ^charts\/(ethadapter|epi|fgt|quorum-node)\/.+$
       args:
         # Make the tool search for charts under the `charts` directory
         - --chart-search-root=charts


### PR DESCRIPTION
Run Pre-commit only on these charts: `ethadapter|epi|fgt|quorum-node`
Why: helm-docs generates renders differently on Windows than on Linux, thus pre-commit will run only charts maintained on Linux 